### PR TITLE
Fix path assertion and clean up terminal and UI code

### DIFF
--- a/kaolinite/tests/test.rs
+++ b/kaolinite/tests/test.rs
@@ -2,7 +2,6 @@ use kaolinite::regex;
 #[cfg(test)]
 use kaolinite::{document::*, event::*, map::*, searching::*, utils::*};
 use std::io::Write;
-use std::ops::{Range, RangeBounds};
 use sugars::hmap;
 
 macro_rules! st {
@@ -935,12 +934,10 @@ fn document_indices() {
 
 #[test]
 fn file_paths() {
-    assert!(get_absolute_path("tests/data/unicode.txt")
-        .unwrap()
-        .starts_with("/home/"));
-    assert!(get_absolute_path("tests/data/unicode.txt")
-        .unwrap()
-        .starts_with("/home/"));
+    let abs_path = get_absolute_path("tests/data/unicode.txt").unwrap();
+    assert!(abs_path.starts_with("/") || abs_path.starts_with("C:\\"));
+    let abs_path2 = get_absolute_path("tests/data/unicode.txt").unwrap();
+    assert!(abs_path2.starts_with("/") || abs_path2.starts_with("C:\\"));
     assert_eq!(
         get_file_name("tests/data/unicode.txt"),
         Some(st!("unicode.txt"))

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -224,9 +224,9 @@ impl TerminalType {
             Self::WindowsConsole => {
                 // Windows Console has limited mouse support
                 #[cfg(target_os = "windows")]
-                true
+                { true }
                 #[cfg(not(target_os = "windows"))]
-                false
+                { false }
             }
             
             _ => false,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -22,7 +22,6 @@ use crossterm::{
 use kaolinite::utils::{width, Size};
 use mlua::AnyUserData;
 use std::collections::HashMap;
-use std::env;
 use std::io::{stdout, Stdout, Write};
 #[cfg(not(target_os = "windows"))]
 use synoptic::Regex;


### PR DESCRIPTION
## Summary
- Fixes file path assertions in tests to support both Unix and Windows paths
- Cleans up terminal code with consistent block usage
- Removes unused imports in tests and UI modules

## Changes

### Tests
- Updated `file_paths` test to assert paths start with `/` or `C:\` for cross-platform compatibility
- Removed unused `std::ops::{Range, RangeBounds}` import from tests

### Terminal Module
- Added braces around `true` and `false` in WindowsConsole mouse support for clarity

### UI Module
- Removed unused `std::env` import

## Test plan
- Run existing tests to ensure path assertions pass on different OSes
- Verify no regressions in terminal mouse support behavior
- Confirm no build errors due to unused imports removal

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/5f6f1792-9507-4534-931e-d06172a375c8