### PR TITLE
Add graceful error handling and debug mode to ox CLI

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -20,6 +20,7 @@ OPTIONS:
   --filetype [name], -f [name] : Set the file type of files opened
   --stdin                      : Reads file from the stdin
   --config-assist              : Activate the configuration assistant
+  --debug, -d                  : Enable debug output for errors
 
 EXAMPLES:
   ox
@@ -29,7 +30,8 @@ EXAMPLES:
   ox -c config.lua test.txt
   ox -r -c ~/.config/.oxrc -f Lua my_file.lua
   tree | ox -r --stdin
-  ox --config-assist\
+  ox --config-assist
+  ox --debug test.txt         # Enable debug output\
 ";
 
 /// Read from the standard input
@@ -47,6 +49,7 @@ pub struct CommandLineInterfaceFlags {
     pub read_only: bool,
     pub stdin: bool,
     pub config_assist: bool,
+    pub debug: bool,
 }
 
 /// Struct to help with starting ox
@@ -74,6 +77,7 @@ impl CommandLineInterface {
                 read_only: j.contains(["-r", "--readonly"]),
                 stdin: j.contains("--stdin"),
                 config_assist: j.contains("--config-assist"),
+                debug: j.contains(["-d", "--debug"]),
             },
             file_type: j.option_arg::<String, Key>(filetype.clone()),
             config_path: j


### PR DESCRIPTION
## Summary
- Introduces a `--debug` CLI flag to enable detailed debug output for errors
- Implements structured error handling with specific exit codes for configuration, runtime, and startup errors
- Enhances error messages with user-friendly guidance and debug details when debug mode is active
- Adds environment variable `OX_DEBUG` to control debug output visibility
- Improves robustness by replacing panics with controlled error reporting and process exits
- Includes comprehensive tests for error handling and debug environment behavior

## Changes

### CLI Enhancements
- Added `--debug` (`-d`) flag to `CommandLineInterface` for enabling debug output
- Sets `OX_DEBUG` environment variable when debug flag is used

### Error Handling Improvements
- Defined constants for exit codes: `EXIT_CONFIG_ERROR`, `EXIT_RUNTIME_ERROR`, `EXIT_STARTUP_ERROR`
- Created `report_error_and_exit` function to print error context and debug info, then exit with appropriate code
- Replaced panics in main error paths with calls to `report_error_and_exit`
- Enhanced editor initialization error messages with possible causes and debug details

### Testing
- Added unit tests for exit codes, debug environment variable behavior, and Lua error handling feedback

## Test plan
- [x] Verify `--debug` flag sets `OX_DEBUG` environment variable
- [x] Confirm error messages show debug details when `OX_DEBUG` is set
- [x] Check that errors cause process exit with correct exit codes
- [x] Run new unit tests to validate error handling logic
- [x] Test editor startup failure scenarios to see improved error output
- [x] Validate configuration assistant failure handling with error reporting

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/cd08c646-e7e3-4536-a3d4-701b4da40bed