### PR TITLE
Enhance clipboard error handling with retries, status, and verbose logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,6 +434,7 @@ dependencies = [
  "error_set",
  "jargon-args",
  "kaolinite",
+ "log",
  "mio",
  "mlua",
  "nix 0.29.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ error_set = "0.7"
 shellexpand = "3.1.0"
 synoptic = "2.2.9"
 regex = "1.11.1"
+log = "0.4"
 
 # Non-windows dependencies (for terminal)
 [target.'cfg(not(target_os = "windows"))'.dependencies]

--- a/src/config/editor.rs
+++ b/src/config/editor.rs
@@ -371,6 +371,18 @@ impl LuaUserData for Editor {
             }
             Ok(())
         });
+        methods.add_method("clipboard_info", |_, editor, ()| {
+            let status = editor.terminal.clipboard_status();
+            let info = format!(
+                "Clipboard Status:\n  Method: {:?}\n  Native Available: {}\n  OSC52 Enabled: {}\n  Platform: {}\n  Last Error: {}",
+                status.method,
+                status.native_available,
+                status.osc52_enabled,
+                status.platform_info,
+                status.last_error.as_deref().unwrap_or("None")
+            );
+            Ok(info)
+        });
         // Document editing
         methods.add_method_mut(
             "insert_at",

--- a/src/config/interface.rs
+++ b/src/config/interface.rs
@@ -22,6 +22,10 @@ pub struct Terminal {
     #[cfg(target_os = "windows")]
     #[allow(dead_code)]
     pub shell: (),
+    // Clipboard configuration
+    pub clipboard_use_osc52: bool,
+    pub clipboard_max_retries: usize,
+    pub clipboard_verbose_logging: bool,
 }
 
 impl Default for Terminal {
@@ -33,6 +37,9 @@ impl Default for Terminal {
             shell: Shell::Bash,
             #[cfg(target_os = "windows")]
             shell: (),
+            clipboard_use_osc52: true,
+            clipboard_max_retries: 3,
+            clipboard_verbose_logging: false,
         }
     }
 }
@@ -60,6 +67,23 @@ impl LuaUserData for Terminal {
         fields.add_field_method_get("shell", |_, _| Ok("windows not supported"));
         #[cfg(target_os = "windows")]
         fields.add_field_method_set("shell", |_, _, _: String| Ok(()));
+        
+        // Clipboard configuration fields
+        fields.add_field_method_get("clipboard_use_osc52", |_, this| Ok(this.clipboard_use_osc52));
+        fields.add_field_method_set("clipboard_use_osc52", |_, this, value| {
+            this.clipboard_use_osc52 = value;
+            Ok(())
+        });
+        fields.add_field_method_get("clipboard_max_retries", |_, this| Ok(this.clipboard_max_retries));
+        fields.add_field_method_set("clipboard_max_retries", |_, this, value| {
+            this.clipboard_max_retries = value;
+            Ok(())
+        });
+        fields.add_field_method_get("clipboard_verbose_logging", |_, this| Ok(this.clipboard_verbose_logging));
+        fields.add_field_method_set("clipboard_verbose_logging", |_, this, value| {
+            this.clipboard_verbose_logging = value;
+            Ok(())
+        });
     }
 }
 

--- a/tests/clipboard_enhanced_test.rs
+++ b/tests/clipboard_enhanced_test.rs
@@ -1,0 +1,270 @@
+// Enhanced clipboard tests with error handling and retry logic
+
+use ox::clipboard::{Clipboard, ClipboardError, ClipboardMethod, ClipboardStatus};
+use std::time::{Duration, Instant};
+
+#[test]
+fn test_clipboard_error_types() {
+    // Test that ClipboardError types are properly defined
+    let errors = vec![
+        ClipboardError::NativeClipboardFailed("test error".to_string()),
+        ClipboardError::ToolNotFound("xclip not found".to_string()),
+        ClipboardError::Timeout,
+        ClipboardError::Locked,
+        ClipboardError::TextTooLarge(1024),
+        ClipboardError::InvalidFormat("bad format".to_string()),
+        ClipboardError::PlatformError("platform issue".to_string()),
+        ClipboardError::OSC52Failed("osc52 error".to_string()),
+    ];
+    
+    for error in errors {
+        // Test that Display trait is implemented
+        let err_str = format!("{}", error);
+        assert!(!err_str.is_empty());
+        
+        // Test conversion to IoError
+        let io_err: std::io::Error = error.into();
+        assert!(!io_err.to_string().is_empty());
+    }
+}
+
+#[test]
+fn test_clipboard_status_tracking() {
+    let mut clipboard = Clipboard::new();
+    let status = clipboard.get_status();
+    
+    // Check that status contains expected fields
+    assert_eq!(status.method, ClipboardMethod::Native);
+    assert!(!status.platform_info.is_empty());
+    assert!(status.last_error.is_none());
+    
+    // Test with OSC52 fallback enabled
+    let mut clipboard_osc = Clipboard::new().with_osc52_fallback();
+    let status_osc = clipboard_osc.get_status();
+    assert!(status_osc.osc52_enabled);
+}
+
+#[test]
+fn test_clipboard_retry_logic() {
+    let mut clipboard = Clipboard::new()
+        .with_max_retries(3)
+        .with_verbose_logging();
+    
+    // Test that retries are configurable
+    let test_text = "Testing retry logic";
+    let start = Instant::now();
+    
+    // This may succeed or fail depending on the environment
+    let _ = clipboard.set_text(test_text);
+    
+    // If it failed and retried, it should have taken some time
+    // (Each retry has a delay)
+    let elapsed = start.elapsed();
+    
+    // Just verify the operation completes without panic
+    assert!(elapsed < Duration::from_secs(5), "Clipboard operation took too long");
+}
+
+#[test]
+fn test_clipboard_method_detection() {
+    let mut clipboard = Clipboard::new().with_osc52_fallback();
+    
+    // Test setting text and checking the method used
+    let test_text = "Method detection test";
+    match clipboard.set_text(test_text) {
+        Ok(()) => {
+            // Check which method was used
+            let method = clipboard.current_method;
+            assert!(
+                matches!(
+                    method,
+                    ClipboardMethod::Native | ClipboardMethod::OSC52 | ClipboardMethod::Cached
+                ),
+                "Unexpected clipboard method: {:?}",
+                method
+            );
+        }
+        Err(_) => {
+            // If clipboard is not available, that's okay in test environment
+            println!("Clipboard not available in test environment");
+        }
+    }
+}
+
+#[test]
+fn test_clipboard_fallback_chain() {
+    let mut clipboard = Clipboard::new()
+        .with_osc52_fallback()
+        .with_max_retries(2);
+    
+    let test_text = "Fallback chain test";
+    
+    // Try to set text - should use fallback chain if native fails
+    match clipboard.set_text(test_text) {
+        Ok(()) => {
+            // Verify last_copied is set regardless of method
+            assert_eq!(clipboard.last_copied(), test_text);
+            
+            // Try to get text
+            match clipboard.get_text() {
+                Ok(text) => {
+                    // Should return either native clipboard or cached text
+                    if clipboard.current_method == ClipboardMethod::Cached {
+                        assert_eq!(text, test_text);
+                    }
+                }
+                Err(_) => {
+                    // In test environment, this is acceptable
+                }
+            }
+        }
+        Err(_) => {
+            // Even if set_text fails, last_copied should be updated
+            assert_eq!(clipboard.last_copied(), test_text);
+        }
+    }
+}
+
+#[test]
+fn test_clipboard_info_output() {
+    let clipboard = Clipboard::new();
+    let info = clipboard.get_clipboard_info();
+    
+    // Verify info contains expected information
+    assert!(info.contains("OSC52 fallback:"));
+    
+    #[cfg(target_os = "windows")]
+    assert!(info.contains("Windows"));
+    
+    #[cfg(target_os = "macos")]
+    assert!(info.contains("macOS"));
+    
+    #[cfg(all(not(target_os = "windows"), not(target_os = "macos")))]
+    assert!(info.contains("Linux"));
+}
+
+#[test]
+fn test_clipboard_error_clearing() {
+    let mut clipboard = Clipboard::new();
+    
+    // Clipboard might not have an error initially
+    assert!(clipboard.last_error().is_none());
+    
+    // After operations, errors can be cleared
+    clipboard.clear_error();
+    assert!(clipboard.last_error().is_none());
+}
+
+#[test]
+fn test_clipboard_large_text_handling() {
+    let mut clipboard = Clipboard::new();
+    
+    // Test with very large text (10MB)
+    let large_text = "x".repeat(10 * 1024 * 1024);
+    
+    match clipboard.set_text(&large_text) {
+        Ok(()) => {
+            // If it succeeds, verify the text was stored
+            assert_eq!(clipboard.last_copied(), large_text);
+        }
+        Err(_) => {
+            // Large text might fail, which is acceptable
+            // But last_copied should still be updated
+            assert_eq!(clipboard.last_copied(), large_text);
+        }
+    }
+}
+
+#[test]
+fn test_clipboard_special_characters() {
+    let mut clipboard = Clipboard::new();
+    
+    let special_texts = vec![
+        "Line 1\nLine 2\nLine 3",      // Newlines
+        "Tab\there\ttest",              // Tabs
+        "Emoji 🎉 🚀 ⭐",               // Emojis
+        "Unicode: αβγδ ΑΒΓΔ",          // Greek letters
+        "Quotes: \"double\" 'single'",  // Quotes
+        "Special: <>&|\\",              // Shell special chars
+        "",                             // Empty string
+    ];
+    
+    for text in special_texts {
+        let _ = clipboard.set_text(text);
+        assert_eq!(clipboard.last_copied(), text);
+    }
+}
+
+#[cfg(all(not(target_os = "windows"), not(target_os = "macos")))]
+mod linux_tests {
+    use super::*;
+    use ox::clipboard::Selection;
+    
+    #[test]
+    fn test_linux_selection_types() {
+        let mut clipboard_primary = Clipboard::new()
+            .with_selection(Selection::Primary);
+        
+        let mut clipboard_clipboard = Clipboard::new()
+            .with_selection(Selection::Clipboard);
+        
+        // Test that different selections can be configured
+        let test_text = "Selection test";
+        
+        // These may fail in headless environment, but shouldn't panic
+        let _ = clipboard_primary.set_text(test_text);
+        let _ = clipboard_clipboard.set_text(test_text);
+    }
+    
+    #[test]
+    fn test_linux_clipboard_info() {
+        // Test that clipboard info properly reports Linux-specific information
+        let clipboard = Clipboard::new();
+        let info = clipboard.get_clipboard_info();
+        
+        // On Linux, the info should contain session type and tool information
+        assert!(info.contains("Linux session:"));
+        
+        // Just verify the info function doesn't panic
+        println!("Linux clipboard info: {}", info);
+    }
+}
+
+#[test]
+fn test_osc52_always_succeeds() {
+    let clipboard = Clipboard::new();
+    
+    // OSC52 should always succeed as it just prints escape sequences
+    let result = clipboard.set_text_osc52("OSC52 test");
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_concurrent_clipboard_access() {
+    use std::sync::{Arc, Mutex};
+    use std::thread;
+    
+    let clipboard = Arc::new(Mutex::new(Clipboard::new()));
+    let mut handles = vec![];
+    
+    // Spawn multiple threads trying to access clipboard
+    for i in 0..5 {
+        let clipboard_clone = Arc::clone(&clipboard);
+        let handle = thread::spawn(move || {
+            let text = format!("Thread {} text", i);
+            if let Ok(mut cb) = clipboard_clone.lock() {
+                let _ = cb.set_text(&text);
+            }
+        });
+        handles.push(handle);
+    }
+    
+    // Wait for all threads to complete
+    for handle in handles {
+        handle.join().unwrap();
+    }
+    
+    // Verify clipboard is still in valid state
+    let clipboard_final = Arc::try_unwrap(clipboard).unwrap().into_inner().unwrap();
+    assert!(!clipboard_final.last_copied().is_empty());
+}


### PR DESCRIPTION
## Summary
- Introduces comprehensive error handling for clipboard operations with detailed error types
- Adds retry logic for transient clipboard failures with configurable max retries
- Implements fallback to OSC52 terminal clipboard and cached clipboard text
- Tracks and exposes clipboard method status and last error for diagnostics
- Enables verbose logging for clipboard operations to aid debugging
- Adds Lua bindings and config options for clipboard behavior
- Improves user feedback on clipboard copy operations
- Includes extensive tests covering error types, retry logic, fallback, and platform specifics

## Changes

### Clipboard Core
- Defined `ClipboardError` enum with variants for common clipboard failure modes
- Added `ClipboardMethod` enum to track native, OSC52, or cached clipboard usage
- Enhanced `Clipboard` struct with retry count, verbose logging, current method, and last error tracking
- Implemented retry loops with delays for `set_text` and `get_text` native clipboard calls
- Fallback to OSC52 on native failure if enabled, with error propagation
- Return cached clipboard text on read failure if OSC52 fallback enabled
- Added methods to get clipboard status, clear and retrieve last error

### Configuration and Integration
- Added clipboard-related config fields to `Terminal` struct: `clipboard_use_osc52`, `clipboard_max_retries`, `clipboard_verbose_logging`
- Exposed clipboard status info to Lua via `clipboard_info` method on `Editor`
- Terminal initializes `Clipboard` with config options
- Terminal's `copy` method returns clipboard method used and logs warnings on errors
- Editor copy method updated to show user feedback with clipboard method and warnings

### Testing
- New comprehensive test suite `clipboard_enhanced_test.rs` covering:
  - Clipboard error type correctness and conversions
  - Clipboard status reporting
  - Retry logic and timing
  - Fallback chain behavior
  - Large text and special character handling
  - Concurrent access
  - Platform-specific clipboard info

## Test plan
- Run new clipboard tests to verify error handling, retries, and fallback
- Manual testing on Windows, macOS, and Linux to confirm clipboard operations and fallback
- Verify user feedback messages on copy operations
- Check verbose logging output when enabled
- Confirm Lua access to clipboard status info

This PR significantly improves clipboard robustness and diagnostics, enhancing user experience and debuggability across platforms.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/3f9760fb-a2d4-4be4-a457-f94fb2f2efca